### PR TITLE
Fix odds of winning for the first and the last candidate

### DIFF
--- a/whitelist.py
+++ b/whitelist.py
@@ -74,7 +74,7 @@ def main():
         total_score = sum(c.score for c in candidates)
         chosen = random.randint(0, int(total_score) - 1)
         for i, c in enumerate(candidates):
-            if chosen <= c.score:
+            if chosen < c.score:
                 whitelist.append(c)
                 candidates.pop(i)
                 break


### PR DESCRIPTION
Situation:
There are only 3 candidates. Each of them has 60 points so their
chances of being whitelisted should be equal. However, current algorithm
gives first candidate in the sorted list greater chance of winning
as he/she will be whitelisted if chosen number is in 0-60 range
(the candidate is effectively holding 61 lottery tickets), while the last
candidate is in disadvantage as he/she will only be whitelisted
if chosen number is in 121-179 range (so the last candidate is holding
only 59 tickets).

This commit should fix the issue.