### PR TITLE
Use standard library for weighted random sampling

### DIFF
--- a/whitelist.py
+++ b/whitelist.py
@@ -69,16 +69,10 @@ def main():
     assert len(candidates) > WHITELIST_NUM + WHITELSIT_SUBSTITUTE_NUM
     # Make sure the order is deterministic so it's reproducible.
     candidates.sort(key=lambda c: c.key)
-    for _ in range(WHITELIST_NUM + WHITELSIT_SUBSTITUTE_NUM):
-        # Sampling. The higher the score, the greater the chance to get picked.
-        total_score = sum(c.score for c in candidates)
-        chosen = random.random() * total_score
-        for i, c in enumerate(candidates):
-            if chosen <= c.score:
-                whitelist.append(c)
-                candidates.pop(i)
-                break
-            chosen -= c.score
+
+    weights = [c.score for c in candidates]
+    k = WHITELIST_NUM + WHITELSIT_SUBSTITUTE_NUM
+    whitelist = random.choices(candidates, weights=weights, k=k)
 
     assert len(whitelist) == WHITELIST_NUM + WHITELSIT_SUBSTITUTE_NUM
     for i, c in enumerate(whitelist):


### PR DESCRIPTION
The original script is very slow and takes over 15 seconds to process the lottery.

I switched the homegrown method to a standard Python weighted [random.choices](https://docs.python.org/3/library/random.html#random.choices) method.

Note that the results it gives are not the same as the implementation differs, but they are still deterministic.

This method works at least 100 times faster.